### PR TITLE
AZ-4 Transition Points

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -72,21 +72,21 @@ LightmapSettings:
     m_FinalGatherRayCount: 256
     m_ReflectionCompression: 2
     m_MixedBakeMode: 2
-    m_BakeBackend: 0
+    m_BakeBackend: 1
     m_PVRSampling: 1
     m_PVRDirectSampleCount: 32
-    m_PVRSampleCount: 500
+    m_PVRSampleCount: 512
     m_PVRBounces: 2
-    m_PVREnvironmentSampleCount: 500
+    m_PVREnvironmentSampleCount: 256
     m_PVREnvironmentReferencePointCount: 2048
-    m_PVRFilteringMode: 2
-    m_PVRDenoiserTypeDirect: 0
-    m_PVRDenoiserTypeIndirect: 0
-    m_PVRDenoiserTypeAO: 0
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
     m_PVRFilterTypeDirect: 0
     m_PVRFilterTypeIndirect: 0
     m_PVRFilterTypeAO: 0
-    m_PVREnvironmentMIS: 0
+    m_PVREnvironmentMIS: 1
     m_PVRCulling: 1
     m_PVRFilteringGaussRadiusDirect: 1
     m_PVRFilteringGaussRadiusIndirect: 5
@@ -121,7 +121,7 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1 &519420028
+--- !u!1 &397884375
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -129,10 +129,10 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 519420032}
-  - component: {fileID: 519420031}
-  - component: {fileID: 519420029}
-  - component: {fileID: 519420030}
+  - component: {fileID: 397884379}
+  - component: {fileID: 397884378}
+  - component: {fileID: 397884377}
+  - component: {fileID: 397884376}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -140,39 +140,50 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!81 &519420029
-AudioListener:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 519420028}
-  m_Enabled: 1
---- !u!114 &519420030
+--- !u!114 &397884376
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 519420028}
+  m_GameObject: {fileID: 397884375}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5fd17ebb69c343c4a9d130a49d2eac15, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  cam: {fileID: 519420031}
   type: 0
-  transitionPoint: {x: 6.65, y: 0}
---- !u!20 &519420031
+  transitionPoints:
+  - transitionPoint: {x: 0.9299698, y: -3.0750284}
+    type: 0
+  - transitionPoint: {x: 4.6984344, y: -1.4841841}
+    type: 0
+  - transitionPoint: {x: 8.568381, y: -2.1733212}
+    type: 0
+  - transitionPoint: {x: 6.308422, y: -4.803767}
+    type: 0
+  - transitionPoint: {x: 9.161159, y: -7.1007757}
+    type: 0
+  - transitionPoint: {x: 11.776119, y: -8.860501}
+    type: 0
+--- !u!81 &397884377
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 397884375}
+  m_Enabled: 1
+--- !u!20 &397884378
 Camera:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 519420028}
+  m_GameObject: {fileID: 397884375}
   m_Enabled: 1
   serializedVersion: 2
-  m_ClearFlags: 2
+  m_ClearFlags: 1
   m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
@@ -198,55 +209,25 @@ Camera:
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_TargetDisplay: 0
-  m_TargetEye: 0
+  m_TargetEye: 3
   m_HDR: 1
-  m_AllowMSAA: 0
+  m_AllowMSAA: 1
   m_AllowDynamicResolution: 0
   m_ForceIntoRT: 0
-  m_OcclusionCulling: 0
+  m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
---- !u!4 &519420032
+--- !u!4 &397884379
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 519420028}
+  m_GameObject: {fileID: 397884375}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.02, y: 0, z: -10}
+  m_LocalPosition: {x: 0, y: 0.34, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2088748144
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2088748145}
-  m_Layer: 0
-  m_Name: GameObject
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2088748145
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2088748144}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -156,16 +156,6 @@ MonoBehaviour:
   transitionPoints:
   - transitionPoint: {x: 0.9299698, y: -3.0750284}
     type: 0
-  - transitionPoint: {x: 4.6984344, y: -1.4841841}
-    type: 0
-  - transitionPoint: {x: 8.568381, y: -2.1733212}
-    type: 0
-  - transitionPoint: {x: 6.308422, y: -4.803767}
-    type: 0
-  - transitionPoint: {x: 9.161159, y: -7.1007757}
-    type: 0
-  - transitionPoint: {x: 11.776119, y: -8.860501}
-    type: 0
 --- !u!81 &397884377
 AudioListener:
   m_ObjectHideFlags: 0

--- a/Packages/ie.itcarlow.screentransitions/Runtime/ScreenTransition.cs
+++ b/Packages/ie.itcarlow.screentransitions/Runtime/ScreenTransition.cs
@@ -8,6 +8,7 @@ public enum TransitionTypes
     HORIZONTAL, VERTICAL
 }
 
+
 [System.Serializable]
 public class TransitionPoint
 {

--- a/Packages/ie.itcarlow.screentransitions/Runtime/ScreenTransition.cs
+++ b/Packages/ie.itcarlow.screentransitions/Runtime/ScreenTransition.cs
@@ -3,25 +3,47 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEditor;
 
+public enum TransitionTypes
+{
+    HORIZONTAL, VERTICAL
+}
+
+[System.Serializable]
+public class TransitionPoint
+{
+    public Vector2 transitionPoint;
+    public TransitionTypes type = TransitionTypes.HORIZONTAL;
+}
+
 public class ScreenTransition : MonoBehaviour
 {
-    public Camera cam;
+    public TransitionTypes type = TransitionTypes.HORIZONTAL;
+    public List<TransitionPoint> transitionPoints;
 
-    public enum transitionTypes { HORIZONTAL, VERTICAL };
-    public transitionTypes type = transitionTypes.HORIZONTAL;
-    public Vector2 transitionPoint = Vector2.zero;
+    private Camera cam;
     private bool transitioning = false;
 
     // Start is called before the first frame update
     void Start()
     {
-        // this component must be attached to a camera
-        cam = this.gameObject.GetComponent<Camera>();
+        // this component must be put on the main camera of the scene
+        cam = Camera.main;
     }
 
     // Update is called once per frame
     void Update()
     {
-        
+
+    }
+
+    public void AddPoint(TransitionPoint t_point)
+    {
+        transitionPoints.Add(t_point);
+    }
+
+    public void RemoveLastPoint()
+    {
+        if (transitionPoints.Count > 0) // make sure points exist first
+            transitionPoints.RemoveAt(transitionPoints.Count - 1); // removes the last item in the list
     }
 }

--- a/Packages/ie.itcarlow.screentransitions/Runtime/ScreenTransitionEditor.cs
+++ b/Packages/ie.itcarlow.screentransitions/Runtime/ScreenTransitionEditor.cs
@@ -40,6 +40,35 @@ public class ScreenTransitionEditor : Editor
             }
         }
 
+        // draw lines between all points in the vector
+        if (sT.transitionPoints.Count > 0)
+        {
+            Handles.DrawLine(mainCam.transform.position, sT.transitionPoints[0].transitionPoint);
+
+            for (int i = 0; i < sT.transitionPoints.Count; i++)
+            {
+                if (i + 1 >= sT.transitionPoints.Count)
+                {
+                    break;
+                }
+
+                Handles.DrawLine(sT.transitionPoints[i].transitionPoint, sT.transitionPoints[i + 1].transitionPoint);
+            }
+
+        }
+
+        // now draw a line from the last point added to the current point being edited
+        Handles.color = new Color(0, 1, 0, 1);
+
+        if (sT.transitionPoints.Count > 0)
+        {
+            Handles.DrawLine(sT.transitionPoints[sT.transitionPoints.Count - 1].transitionPoint, currPoint.transitionPoint);
+        }
+        else
+        {
+            Handles.DrawLine(mainCam.transform.position, currPoint.transitionPoint);
+        } 
+
         // handle point used to add new transition points to the list
         Vector2 newPos = Handles.PositionHandle(currPoint.transitionPoint, Quaternion.identity);
         currPoint.transitionPoint = newPos;

--- a/Packages/ie.itcarlow.screentransitions/Runtime/ScreenTransitionEditor.cs
+++ b/Packages/ie.itcarlow.screentransitions/Runtime/ScreenTransitionEditor.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_EDITOR
+﻿//#if UNITY_EDITOR
 
 using System.Collections;
 using System.Collections.Generic;
@@ -9,31 +9,61 @@ using UnityEngine;
 [CustomEditor(typeof(ScreenTransition))]
 public class ScreenTransitionEditor : Editor
 {
+    private ScreenTransition sT;
+    private TransitionPoint currPoint = new TransitionPoint();
+	private Camera mainCam;
+
+    private void OnEnable()
+	{
+		// Method 1
+		mainCam = Camera.main;
+		sT = mainCam.GetComponent<ScreenTransition>();
+        currPoint.transitionPoint = mainCam.transform.position + new Vector3(1, 1, 0);
+	}
+
     protected virtual void OnSceneGUI()
     {
-        ScreenTransition customClass = (ScreenTransition)target;
-
         // Safety against selecting a null GameObject
-        if (customClass == null)
+        if (sT == null)
         {
             return;
         }
 
-        Handles.color = Color.yellow;
-        Handles.DrawLine(customClass.transform.position, customClass.transitionPoint);
-        Vector2 newPos = Handles.PositionHandle(customClass.transitionPoint, Quaternion.identity);
+        // draw Handles for all points
+        if(sT.transitionPoints.Count > 0)
+        {
+            foreach(TransitionPoint point in sT.transitionPoints)
+            {
+                Handles.color = Color.yellow;
+                Vector2 pos = Handles.PositionHandle(point.transitionPoint, Quaternion.identity);
+                point.transitionPoint = pos;
+            }
+        }
 
-        if (customClass.type == ScreenTransition.transitionTypes.HORIZONTAL)
-        {
-            customClass.transitionPoint.x = newPos.x;
-            customClass.transitionPoint.y = customClass.transform.position.y;
-        }
-        else
-        {
-            customClass.transitionPoint.x = customClass.transform.position.x;
-            customClass.transitionPoint.y = newPos.y;
-        }
-            
+        // handle point used to add new transition points to the list
+        Vector2 newPos = Handles.PositionHandle(currPoint.transitionPoint, Quaternion.identity);
+        currPoint.transitionPoint = newPos;
+        Handles.Label(newPos, "Current Point");
     }
+
+    public override void OnInspectorGUI()
+	{
+		if (GUILayout.Button("Add Point"))
+		{
+            currPoint.type = sT.type;
+            Vector2 vec = currPoint.transitionPoint;
+            sT.AddPoint(currPoint);
+            currPoint = new TransitionPoint();
+            currPoint.transitionPoint = vec;
+        }
+
+        if (GUILayout.Button("Remove Last Point"))
+        {
+            sT.RemoveLastPoint();
+        }
+
+        // Draw default inspector after button...
+        base.OnInspectorGUI();
+	}
 }
-#endif
+//#endif

--- a/Packages/ie.itcarlow.screentransitions/Runtime/ScreenTransitionEditor.cs
+++ b/Packages/ie.itcarlow.screentransitions/Runtime/ScreenTransitionEditor.cs
@@ -1,4 +1,4 @@
-﻿//#if UNITY_EDITOR
+﻿#if UNITY_EDITOR
 
 using System.Collections;
 using System.Collections.Generic;
@@ -95,4 +95,4 @@ public class ScreenTransitionEditor : Editor
         base.OnInspectorGUI();
 	}
 }
-//#endif
+#endif

--- a/Packages/ie.itcarlow.screentransitions/Tests/ScreenTransitionTests.cs
+++ b/Packages/ie.itcarlow.screentransitions/Tests/ScreenTransitionTests.cs
@@ -1,0 +1,74 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.SceneManagement;
+
+namespace Tests
+{
+    public class ScreenTransitionTests
+    {
+        private Camera mainCam;
+
+        [SetUp]
+        public void Setup()
+        {
+            SceneManager.LoadScene("SampleScene", LoadSceneMode.Single);
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            SceneManager.UnloadSceneAsync("SampleScene");
+        }
+
+        [UnityTest]
+        public IEnumerator AddingPoints()
+        {
+            setupCamera();
+            TransitionPoint point = new TransitionPoint();
+
+            point.transitionPoint = new Vector2(1.0f, 0.0f);
+            mainCam.GetComponent<ScreenTransition>().AddPoint(point);
+
+            point = new TransitionPoint();
+
+            point.transitionPoint = new Vector2(2.0f, 0.0f);
+            mainCam.GetComponent<ScreenTransition>().AddPoint(point);
+            yield return null;
+
+            Assert.AreEqual(2, mainCam.GetComponent<ScreenTransition>().transitionPoints.Count);
+
+        }
+
+        [UnityTest]
+        public IEnumerator RemovingLastAddedPoint()
+        {
+            setupCamera();
+
+            TransitionPoint point = new TransitionPoint();
+            point.transitionPoint = new Vector2(1.0f, 0.0f);
+            mainCam.GetComponent<ScreenTransition>().AddPoint(point);
+
+            point = new TransitionPoint();
+            point.transitionPoint = new Vector2(2.0f, 0.0f);
+            mainCam.GetComponent<ScreenTransition>().AddPoint(point);
+
+
+            mainCam.GetComponent<ScreenTransition>().RemoveLastPoint();
+            yield return null;
+
+            Assert.AreEqual(1, mainCam.GetComponent<ScreenTransition>().transitionPoints.Count);
+
+        }
+
+        private void setupCamera()
+        {
+            mainCam = Camera.main;
+
+            // remove any other points that may exist on the camera for our tests
+            mainCam.GetComponent<ScreenTransition>().transitionPoints.Clear();
+        }
+    }
+}

--- a/Packages/ie.itcarlow.screentransitions/Tests/ScreenTransitionTests.cs.meta
+++ b/Packages/ie.itcarlow.screentransitions/Tests/ScreenTransitionTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a9a626fdecdc0c24e9a2a9bda2ec60f9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -4,5 +4,8 @@
 EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
-  m_Scenes: []
+  m_Scenes:
+  - enabled: 1
+    path: Assets/Scenes/SampleScene.unity
+    guid: 2cda990e2423bbf4892e6590ba056729
   m_configObjects: {}


### PR DESCRIPTION
### What Changed
Transition Points can be added via the Screen Transition component.
A "Current Point" can be used to place where a Transition Point would like to be.
Hitting "Add Point" on the Inspector under the Component will assign that Transition Point, and the Type of Transition, to a List.
The last added point can also be removed through the Inspector.

All Transition Points have lines drawn between them, to show the progression between each point.
A final line is drawn to the "Current Point" from the last added Transition Point.