### PR TITLE
Az 10 camera destination reach

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -155,7 +155,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   type: 0
   transitionPoints:
-  - transitionPoint: {x: 6.58, y: 0}
+  - transitionPoint: {x: 20, y: 0}
     type: 0
   transitionSpeed: 2
   transitioning: 0

--- a/Packages/ie.itcarlow.screentransitions/Runtime/ScreenTransition.cs
+++ b/Packages/ie.itcarlow.screentransitions/Runtime/ScreenTransition.cs
@@ -25,6 +25,8 @@ public class ScreenTransition : MonoBehaviour
 
     private Camera cam;
     private TransitionPoint pickedPoint;
+    private float minDistanceToStop = 0.1f;
+    private float speedCap = 10.0f;
 
     // Start is called before the first frame update
     void Start()
@@ -76,15 +78,32 @@ public class ScreenTransition : MonoBehaviour
 
         normal = (pickedPoint.transitionPoint - point).normalized;
 
+        // if the user put the speed at an over the top amount
+        // it isn't possible for the camera to not reach the point in about 1 frame,
+        // so just place the camera at that point
+        bool tooFast = transitionSpeed > speedCap;
+
         // now that we have the normal, we can begin moving towards it
-        while (true)
+        while (!tooFast)
         { // camera stopping will be implemented in a later feature
             cam.transform.position = new Vector3(cam.transform.position.x + (normal.x * transitionSpeed),
                 cam.transform.position.y + (normal.y * transitionSpeed), cam.transform.position.z);
-
+            
             yield return new WaitForSeconds(0.01f);
+
+            // since the camera could be moving towards our transition point at any direction,
+            // we will do a simple check to see if the camera is close enough
+            // then set the camera's position to the specified point, and stop transitioning
+
+            float distanceToPoint = Vector2.Distance(cam.transform.position, pickedPoint.transitionPoint);
+
+            if(distanceToPoint < minDistanceToStop)
+            {
+                break;
+            }
         }
 
+        cam.transform.position = pickedPoint.transitionPoint;
         transitioning = false;
     }
 }

--- a/Packages/ie.itcarlow.screentransitions/Runtime/ScreenTransition.cs
+++ b/Packages/ie.itcarlow.screentransitions/Runtime/ScreenTransition.cs
@@ -103,7 +103,7 @@ public class ScreenTransition : MonoBehaviour
             }
         }
 
-        cam.transform.position = pickedPoint.transitionPoint;
+        cam.transform.position = new Vector3(pickedPoint.transitionPoint.x, pickedPoint.transitionPoint.y, cam.transform.position.z);
         transitioning = false;
     }
 }

--- a/Packages/ie.itcarlow.screentransitions/Tests/ScreenTransitionTests.cs
+++ b/Packages/ie.itcarlow.screentransitions/Tests/ScreenTransitionTests.cs
@@ -83,6 +83,23 @@ namespace Tests
 
         }
 
+        [UnityTest]
+        public IEnumerator CameraStops()
+        {
+            setupCamera();
+
+            TransitionPoint point = new TransitionPoint();
+            point.transitionPoint = new Vector2(1.0f, 0.0f);
+            mainCam.GetComponent<ScreenTransition>().AddPoint(point);
+
+            mainCam.GetComponent<ScreenTransition>().BeginTransition(0);
+
+            yield return new WaitForSeconds(1.5f);
+
+            Assert.AreEqual(false, mainCam.GetComponent<ScreenTransition>().transitioning);
+
+        }
+
         private void setupCamera()
         {
             mainCam = Camera.main;


### PR DESCRIPTION
### What Changed
Camera can now successfully stop when coming near to the specified Transition Point.
There is a speed cap put in place if the Transition Speed is set too high, to assure that the Transition works properly.